### PR TITLE
ci: add integration test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,96 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  integration:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libseccomp-dev jq containerd
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build kontainer-runtime release binary
+        run: ./gradlew linkReleaseExecutableLinuxX64
+
+      - name: Make verify scripts executable
+        run: chmod +x test-scripts/*.sh
+
+      - name: Start containerd
+        run: |
+          sudo systemctl enable containerd
+          sudo systemctl start containerd
+          sudo systemctl status containerd --no-pager
+
+      - name: Pull alpine image
+        run: sudo ctr image pull docker.io/library/alpine:latest
+
+      - name: Run container and host-side verification
+        run: |
+          BIN="$(pwd)/build/bin/linuxX64/releaseExecutable/kontainer-runtime.kexe"
+
+          # Start the container in the background. verify-from-container.sh ends
+          # with `sleep 10`, giving the host script a window to read /proc/<pid>/.
+          sudo ctr run --rm \
+              --runc-binary="$BIN" \
+              --seccomp --read-only \
+              --memory-limit 134217728 --cpus 0.5 \
+              --uidmap "0:100000:65536" --gidmap "0:100000:65536" \
+              --user 1000:1000 --hostname my-test-container \
+              docker.io/library/alpine:latest \
+              test-verify \
+              sh -c "$(cat test-scripts/verify-from-container.sh)" \
+              > container.log 2>&1 &
+          CTR_PID=$!
+          echo "ctr PID: $CTR_PID"
+
+          # Give the container time to start so its /proc/<pid>/ entries are populated.
+          sleep 5
+
+          sudo ./test-scripts/verify-from-host.sh test-verify > host.log 2>&1
+
+          # Wait for the container to finish its trailing sleep and exit.
+          wait $CTR_PID
+
+      - name: Show captured logs
+        if: always()
+        run: |
+          echo "=== container.log ==="
+          cat container.log || true
+          echo ""
+          echo "=== host.log ==="
+          cat host.log || true
+
+      - name: Check expectations
+        run: |
+          ./test-scripts/check-expectations.sh container.log
+          ./test-scripts/check-expectations.sh host.log
+
+      - name: Upload logs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-logs
+          path: |
+            container.log
+            host.log

--- a/src/nativeMain/kotlin/cgroup/Cgroup.kt
+++ b/src/nativeMain/kotlin/cgroup/Cgroup.kt
@@ -57,19 +57,30 @@ fun setupCgroup(
         createDirectories(fullPath, 0x1EDu) // 0x1ED = 0755 octal
         Logger.debug("created cgroup directory: $fullPath")
 
-        // Enable controllers in subtree_control
-        // Only enable controllers that are actually needed based on resources
+        // Enable controllers at every ancestor of the leaf cgroup.
+        // In cgroup v2 a controller is only available in a child cgroup if its parent's
+        // cgroup.subtree_control contains +<controller>. For a nested path like
+        // "default/test-verify" we must enable controllers in both
+        // /sys/fs/cgroup/cgroup.subtree_control and /sys/fs/cgroup/default/cgroup.subtree_control,
+        // not only the root, otherwise opening memory.max etc. in the leaf fails with EACCES.
         val requiredControllers = getRequiredControllers(resources)
         if (requiredControllers.isNotEmpty()) {
-            val subtreeControlPath = "$CGROUP_ROOT/$CGROUP_SUBTREE_CONTROL"
+            val segments = normalizedPath.split("/").filter { it.isNotEmpty() }
+            val ancestorPaths = mutableListOf(CGROUP_ROOT)
+            for (i in 0 until segments.size - 1) {
+                ancestorPaths.add("${ancestorPaths.last()}/${segments[i]}")
+            }
 
-            for (controller in requiredControllers) {
-                try {
-                    writeTextFile(subtreeControlPath, "+$controller")
-                    Logger.debug("enabled $controller controller")
-                } catch (e: Exception) {
-                    Logger.error("failed to enable $controller controller: ${e.message}")
-                    throw Exception("Failed to enable required cgroup controller: $controller", e)
+            for (ancestorPath in ancestorPaths) {
+                val subtreeControlPath = "$ancestorPath/$CGROUP_SUBTREE_CONTROL"
+                for (controller in requiredControllers) {
+                    try {
+                        writeTextFile(subtreeControlPath, "+$controller")
+                        Logger.debug("enabled $controller controller in $ancestorPath")
+                    } catch (e: Exception) {
+                        Logger.error("failed to enable $controller controller in $ancestorPath: ${e.message}")
+                        throw Exception("Failed to enable required cgroup controller: $controller in $ancestorPath", e)
+                    }
                 }
             }
         }

--- a/test-scripts/check-expectations.sh
+++ b/test-scripts/check-expectations.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Verify that critical container security and isolation features are configured
+# as expected by parsing the output of verify-from-container.sh or verify-from-host.sh.
+#
+# Usage: check-expectations.sh <log-file>
+# Auto-detects whether the log is container-side or host-side from a marker line.
+# Exits 0 if every assertion passes, 1 if any fail, 2 on usage error.
+
+set -uo pipefail
+
+LOG="${1:?usage: $0 <log-file>}"
+
+if [ ! -f "$LOG" ]; then
+    echo "ERROR: log file not found: $LOG" >&2
+    exit 2
+fi
+
+FAIL=0
+
+assert_match() {
+    local name="$1"
+    local pattern="$2"
+    if grep -qE "$pattern" "$LOG"; then
+        echo "  PASS  $name"
+    else
+        echo "  FAIL  $name"
+        echo "        pattern not found: $pattern"
+        FAIL=1
+    fi
+}
+
+assert_count_at_least() {
+    local name="$1"
+    local pattern="$2"
+    local min="$3"
+    local got
+    got=$(grep -cE "$pattern" "$LOG" || true)
+    if [ "$got" -ge "$min" ]; then
+        echo "  PASS  $name ($got >= $min)"
+    else
+        echo "  FAIL  $name ($got < $min)"
+        echo "        pattern: $pattern"
+        FAIL=1
+    fi
+}
+
+if grep -q "KONTAINER-RUNTIME COMPREHENSIVE TEST" "$LOG"; then
+    echo "Checking container-side log: $LOG"
+    assert_match         "PID 1 inside container"        'Container sees itself as PID: 1'
+    assert_match         "UTS namespace hostname"        'my-test-container'
+    assert_match         "uid_map 0 -> 100000 (size 65536)" '^[[:space:]]*0[[:space:]]+100000[[:space:]]+65536[[:space:]]*$'
+    assert_match         "seccomp filter mode active"    '^Seccomp:[[:space:]]+2'
+    assert_match         "no_new_privs is set"           '^NoNewPrivs:[[:space:]]+1'
+    assert_match         "old root not visible (pivot_root)" 'OK: Old root not visible'
+    assert_match         "rootfs is readonly"            'OK: Root is readonly'
+    assert_match         "memory.max = 134217728 (128MB)" '^134217728$'
+    assert_match         "cpu.max = 50000 100000"        '^50000 100000$'
+elif grep -q "HOST-SIDE CONTAINER VERIFICATION" "$LOG"; then
+    echo "Checking host-side log: $LOG"
+    # PID and user namespaces should differ from host (verify script prints "Different? YES" twice)
+    assert_count_at_least "PID and user namespaces differ from host" 'Different\? YES' 2
+    assert_match         "uid_map 0 -> 100000 (size 65536)" '^[[:space:]]*0[[:space:]]+100000[[:space:]]+65536[[:space:]]*$'
+    assert_match         "seccomp filter mode active"    '^Seccomp:[[:space:]]+2'
+    assert_match         "no_new_privs is set"           '^NoNewPrivs:[[:space:]]+1'
+    assert_match         "memory.max = 134217728 (128MB)" '^134217728$'
+    assert_match         "cpu.max = 50000 100000"        '^50000 100000$'
+else
+    echo "ERROR: $LOG does not look like a verify-from-container.sh or verify-from-host.sh output" >&2
+    exit 2
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+    echo ""
+    echo "FAILED: one or more expectations not met."
+    exit 1
+fi
+
+echo ""
+echo "OK: all expectations met."
+exit 0

--- a/test-scripts/test-with-containerd.md
+++ b/test-scripts/test-with-containerd.md
@@ -2,10 +2,23 @@
 
 ## Prerequisites
 
-Set symbolic link for kontainer-runtime binary
+There are two ways to make `ctr` invoke kontainer-runtime as the OCI runtime.
+
+### Option A. Pass `--runc-binary` to `ctr run` (recommended)
+
+No setup needed beyond building the binary. Used by `.github/workflows/integration.yml`.
+
+```bash
+BIN="$HOME/kontainer-runtime/build/bin/linuxX64/debugExecutable/kontainer-runtime.kexe"
+sudo ctr run --runc-binary="$BIN" ...
+```
+
+### Option B. Symlink the binary as `/usr/sbin/runc`
+
+Useful if you do not want to repeat `--runc-binary` for every command.
 
 ```
-sudo ln -sf /home/ternbusty/kontainer-runtime/build/bin/linuxX64/debugExecutable/kontainer-runtime.kexe /usr/sbin/runc
+sudo ln -sf $HOME/kontainer-runtime/build/bin/linuxX64/debugExecutable/kontainer-runtime.kexe /usr/sbin/runc
 ```
 
 ## Verification
@@ -13,7 +26,9 @@ sudo ln -sf /home/ternbusty/kontainer-runtime/build/bin/linuxX64/debugExecutable
 ### Test Command to Check from Inside Container
 
 ```bash
+BIN="$HOME/kontainer-runtime/build/bin/linuxX64/debugExecutable/kontainer-runtime.kexe"
 sudo ctr run --rm \
+    --runc-binary="$BIN" \
     --seccomp \
     --read-only \
     --memory-limit 134217728 \
@@ -26,6 +41,8 @@ sudo ctr run --rm \
     test-alpine-comprehensive \
     sh -c "$(cat verify-from-container.sh)"
 ```
+
+If you used Option B (symlink), drop the `BIN=...` line and the `--runc-binary` flag.
 
 output
 


### PR DESCRIPTION
## Summary

- Run [test-scripts/verify-from-container.sh](test-scripts/verify-from-container.sh) (21 sections) and [test-scripts/verify-from-host.sh](test-scripts/verify-from-host.sh) (12 sections) against the release binary via `ctr` in CI, so namespace, cgroup, seccomp, capability, and `pivot_root` regressions are caught before merge.
- New `test-scripts/check-expectations.sh` parses the verify scripts' output and asserts critical isolation invariants (PID 1 inside container, `uid_map` `0 100000 65536`, `Seccomp: 2`, `NoNewPrivs: 1`, `OK: Old root not visible`, `OK: Root is readonly`, `memory.max=134217728`, `cpu.max=50000 100000`).
- New `.github/workflows/integration.yml` builds with `linkReleaseExecutableLinuxX64`, installs `containerd` from apt, then `ctr run --runc-binary=$BIN` in the background, runs the host script during the trailing `sleep 10`, and gates the job on the assertions. Logs are uploaded as artifacts on success and failure.
- `test-scripts/test-with-containerd.md` documents both the `--runc-binary` path (used by CI) and the existing `/usr/sbin/runc` symlink approach.

This is the foundation for an upcoming `Syscall` interface refactor — without integration coverage, refactor PRs cannot be safely merged because `./gradlew kotest` only checks pure logic, not the actual kernel-facing behavior.

## Test plan

- [ ] CI run on this PR is green (baseline established)
- [ ] Follow-up: deliberately break a namespace flag on a throwaway branch and confirm the workflow turns red, validating that the assertions actually detect regressions
- [ ] Confirm artifact upload works on both success and failure paths