### PR TITLE
refactor: move parseSignal into command/Kill.kt

### DIFF
--- a/src/nativeMain/kotlin/command/Kill.kt
+++ b/src/nativeMain/kotlin/command/Kill.kt
@@ -2,11 +2,10 @@ package command
 
 import kotlinx.cinterop.ExperimentalForeignApi
 import logger.Logger
-import platform.posix.exit
+import platform.posix.*
 import state.loadState
 import state.refreshStatus
 import syscall.killProcess
-import syscall.parseSignal
 
 /**
  * Kill command - Send a signal to a container
@@ -79,5 +78,37 @@ fun kill(
     } catch (e: Exception) {
         Logger.error("failed to kill container: ${e.message ?: "unknown"}")
         exit(1)
+    }
+}
+
+/**
+ * Parse a signal name (e.g. "SIGKILL", "KILL") or number (e.g. "9") to its signal number.
+ */
+private fun parseSignal(signalStr: String): Int {
+    signalStr.toIntOrNull()?.let { return it }
+
+    val normalized = if (signalStr.startsWith("SIG")) signalStr else "SIG$signalStr"
+
+    return when (normalized.uppercase()) {
+        "SIGHUP" -> SIGHUP
+        "SIGINT" -> SIGINT
+        "SIGQUIT" -> SIGQUIT
+        "SIGILL" -> SIGILL
+        "SIGABRT" -> SIGABRT
+        "SIGFPE" -> SIGFPE
+        "SIGKILL" -> SIGKILL
+        "SIGSEGV" -> SIGSEGV
+        "SIGPIPE" -> SIGPIPE
+        "SIGALRM" -> SIGALRM
+        "SIGTERM" -> SIGTERM
+        "SIGUSR1" -> SIGUSR1
+        "SIGUSR2" -> SIGUSR2
+        "SIGCHLD" -> SIGCHLD
+        "SIGCONT" -> SIGCONT
+        "SIGSTOP" -> SIGSTOP
+        "SIGTSTP" -> SIGTSTP
+        "SIGTTIN" -> SIGTTIN
+        "SIGTTOU" -> SIGTTOU
+        else -> throw IllegalArgumentException("Unknown signal: $signalStr")
     }
 }

--- a/src/nativeMain/kotlin/syscall/Signal.kt
+++ b/src/nativeMain/kotlin/syscall/Signal.kt
@@ -5,46 +5,6 @@ import logger.Logger
 import platform.posix.*
 
 /**
- * Parse signal string to signal number
- *
- * Accepts both signal names (e.g., "SIGKILL", "KILL") and numbers (e.g., "9").
- *
- * @param signalStr Signal string to parse
- * @return Signal number
- * @throws IllegalArgumentException if signal is invalid
- */
-fun parseSignal(signalStr: String): Int {
-    // Try parsing as number first
-    signalStr.toIntOrNull()?.let { return it }
-
-    // Parse as signal name (with or without SIG prefix)
-    val normalized = if (signalStr.startsWith("SIG")) signalStr else "SIG$signalStr"
-
-    return when (normalized.uppercase()) {
-        "SIGHUP" -> SIGHUP
-        "SIGINT" -> SIGINT
-        "SIGQUIT" -> SIGQUIT
-        "SIGILL" -> SIGILL
-        "SIGABRT" -> SIGABRT
-        "SIGFPE" -> SIGFPE
-        "SIGKILL" -> SIGKILL
-        "SIGSEGV" -> SIGSEGV
-        "SIGPIPE" -> SIGPIPE
-        "SIGALRM" -> SIGALRM
-        "SIGTERM" -> SIGTERM
-        "SIGUSR1" -> SIGUSR1
-        "SIGUSR2" -> SIGUSR2
-        "SIGCHLD" -> SIGCHLD
-        "SIGCONT" -> SIGCONT
-        "SIGSTOP" -> SIGSTOP
-        "SIGTSTP" -> SIGTSTP
-        "SIGTTIN" -> SIGTTIN
-        "SIGTTOU" -> SIGTTOU
-        else -> throw IllegalArgumentException("Unknown signal: $signalStr")
-    }
-}
-
-/**
  * Send a signal to a process
  *
  * Wrapper around kill(2) system call.


### PR DESCRIPTION
## Summary

- `parseSignal` in [src/nativeMain/kotlin/syscall/Signal.kt](src/nativeMain/kotlin/syscall/Signal.kt) is a pure string-to-signal-number parser, not a syscall wrapper. The only caller is `command/Kill.kt`, so it now lives there as a `private fun`.
- `killProcess` (the actual `kill(2)` wrapper) stays in `syscall/Signal.kt`.

This is the first preparatory step toward introducing a `Syscall` interface (mockable seam for future Kotest unit tests). Keeping `syscall/` to actual syscall wrappers makes the next steps mechanical.

No functional change. Build, lint, and the integration workflow added in [#17](https://github.com/ternbusty/kontainer-runtime/pull/17) should all be green.

## Test plan

- [ ] CI (`build`) passes
- [ ] Integration workflow (`integration`) passes — a regression in `kill <signal>` parsing would surface there since the kill flow is exercised end-to-end