### PR TITLE
refactor: introduce Cgroup interface and consolidate cgroupfs operations

### DIFF
--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -1,4 +1,5 @@
 import bootstrap.kontainer_is_init_process
+import cgroup.CgroupV2
 import channel.InitReceiver
 import channel.MainSender
 import channel.NotifyListener
@@ -39,6 +40,7 @@ fun main(args: Array<String>): Unit =
 
         val syscall = LinuxSyscall()
         val fs = RealFileSystem()
+        val cgroup = CgroupV2(fs)
 
         // If this is Stage-2 (init process) forked by bootstrap.c
         if (isInit != 0 || (args.size == 1 && args[0] == "__init__")) {
@@ -152,7 +154,7 @@ fun main(args: Array<String>): Unit =
             )
 
             override fun execute() {
-                create(syscall, fs, rootPath, containerId, bundle, pidFile)
+                create(syscall, fs, cgroup, rootPath, containerId, bundle, pidFile)
             }
         }
 
@@ -208,7 +210,7 @@ fun main(args: Array<String>): Unit =
             )
 
             override fun execute() {
-                delete(syscall, fs, rootPath, containerId, force)
+                delete(syscall, fs, cgroup, rootPath, containerId, force)
             }
         }
 
@@ -226,7 +228,7 @@ fun main(args: Array<String>): Unit =
             )
 
             override fun execute() {
-                ps(fs, rootPath, containerId, format)
+                ps(fs, cgroup, rootPath, containerId, format)
             }
         }
 

--- a/src/nativeMain/kotlin/cgroup/Cgroup.kt
+++ b/src/nativeMain/kotlin/cgroup/Cgroup.kt
@@ -1,342 +1,36 @@
 package cgroup
 
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.memScoped
-import logger.Logger
-import platform.posix.F_OK
-import platform.posix.access
 import spec.LinuxResources
-import utils.FileSystem
 
 /**
- * Cgroup v2 management
+ * Abstraction over cgroup operations the runtime invokes.
  *
- * Provides basic cgroup v2 support for resource limitation
+ * Domain code (process / command) calls methods on a [Cgroup] instance
+ * rather than touching cgroupfs directly. The production implementation
+ * is [CgroupV2]; tests inject a fake.
  */
+interface Cgroup {
+    /**
+     * Create a cgroup at [cgroupPath] (relative to the cgroup root), enable the
+     * controllers required by [resources] in every ancestor's cgroup.subtree_control,
+     * place [pid] in the leaf cgroup.procs, and apply the resource limits.
+     *
+     * No-op when both [cgroupPath] and [resources] are null.
+     */
+    fun setup(
+        pid: Int,
+        cgroupPath: String?,
+        resources: LinuxResources?,
+    )
 
-private const val CGROUP_ROOT = "/sys/fs/cgroup"
-private const val CGROUP_PROCS = "cgroup.procs"
-private const val CGROUP_SUBTREE_CONTROL = "cgroup.subtree_control"
-private const val MEMORY_MAX = "memory.max"
-private const val MEMORY_LOW = "memory.low"
-private const val MEMORY_SWAP_MAX = "memory.swap.max"
-private const val CPU_WEIGHT = "cpu.weight"
-private const val CPU_MAX = "cpu.max"
+    /**
+     * Best-effort removal of the cgroup directory at [cgroupPath]. Logs a warning
+     * on failure (e.g. cgroup not empty) and never throws.
+     */
+    fun cleanup(cgroupPath: String?)
 
-/**
- * Setup cgroup for a process
- *
- * Creates cgroup directory structure, enables controllers, and applies resource limits
- *
- * @param pid Process ID to add to cgroup
- * @param cgroupPath Relative path from /sys/fs/cgroup (e.g., "mycontainer")
- * @param resources Resource limits to apply
- */
-@OptIn(ExperimentalForeignApi::class)
-fun setupCgroup(
-    fs: FileSystem,
-    pid: Int,
-    cgroupPath: String?,
-    resources: LinuxResources?,
-) {
-    // Skip if no cgroup path or resources specified
-    if (cgroupPath == null && resources == null) {
-        return
-    }
-
-    memScoped {
-        // Normalize cgroup path: remove leading slash if present (for absolute paths from containerd)
-        val normalizedPath =
-            cgroupPath?.removePrefix("/") ?: "kontainer-$pid"
-        val fullPath = "$CGROUP_ROOT/$normalizedPath"
-
-        Logger.debug("setting up cgroup at $fullPath")
-
-        // Create cgroup directory
-        fs.createDirectories(fullPath, 0x1EDu) // 0x1ED = 0755 octal
-        Logger.debug("created cgroup directory: $fullPath")
-
-        // Enable controllers at every ancestor of the leaf cgroup.
-        // In cgroup v2 a controller is only available in a child cgroup if its parent's
-        // cgroup.subtree_control contains +<controller>. For a nested path like
-        // "default/test-verify" we must enable controllers in both
-        // /sys/fs/cgroup/cgroup.subtree_control and /sys/fs/cgroup/default/cgroup.subtree_control,
-        // not only the root, otherwise opening memory.max etc. in the leaf fails with EACCES.
-        val requiredControllers = getRequiredControllers(resources)
-        if (requiredControllers.isNotEmpty()) {
-            val segments = normalizedPath.split("/").filter { it.isNotEmpty() }
-            val ancestorPaths = mutableListOf(CGROUP_ROOT)
-            for (i in 0 until segments.size - 1) {
-                ancestorPaths.add("${ancestorPaths.last()}/${segments[i]}")
-            }
-
-            for (ancestorPath in ancestorPaths) {
-                val subtreeControlPath = "$ancestorPath/$CGROUP_SUBTREE_CONTROL"
-                for (controller in requiredControllers) {
-                    try {
-                        fs.writeTextFile(subtreeControlPath, "+$controller")
-                        Logger.debug("enabled $controller controller in $ancestorPath")
-                    } catch (e: Exception) {
-                        Logger.error("failed to enable $controller controller in $ancestorPath: ${e.message}")
-                        throw Exception("Failed to enable required cgroup controller: $controller in $ancestorPath", e)
-                    }
-                }
-            }
-        }
-
-        // Add process to cgroup
-        val procsPath = "$fullPath/$CGROUP_PROCS"
-        try {
-            fs.writeTextFile(procsPath, pid.toString())
-            Logger.debug("added PID $pid to cgroup")
-        } catch (e: Exception) {
-            Logger.error("failed to add PID to cgroup: ${e.message}")
-            throw Exception("Failed to add PID to cgroup", e)
-        }
-
-        // Apply resource limits if specified
-        if (resources != null) {
-            applyResources(fs, fullPath, resources)
-        }
-    }
-}
-
-/**
- * Apply resource limits to cgroup
- */
-@OptIn(ExperimentalForeignApi::class)
-private fun applyResources(
-    fs: FileSystem,
-    cgroupPath: String,
-    resources: LinuxResources,
-) {
-    // Apply memory limits
-    resources.memory?.let { memory ->
-        applyMemoryLimits(fs, cgroupPath, memory.limit, memory.reservation, memory.swap)
-    }
-
-    // Apply CPU limits
-    resources.cpu?.let { cpu ->
-        applyCpuLimits(fs, cgroupPath, cpu.shares, cpu.quota, cpu.period)
-    }
-}
-
-/**
- * Apply memory resource limits
- */
-@OptIn(ExperimentalForeignApi::class)
-private fun applyMemoryLimits(
-    fs: FileSystem,
-    cgroupPath: String,
-    limit: Long?,
-    reservation: Long?,
-    swap: Long?,
-) {
-    // Set memory.max (memory limit)
-    limit?.let {
-        val memoryMaxPath = "$cgroupPath/$MEMORY_MAX"
-        val value = if (it == -1L) "max" else it.toString()
-        writeCgroupFile(fs, memoryMaxPath, value, "memory.max")
-    }
-
-    // Set memory.low (memory reservation / soft limit)
-    reservation?.let {
-        val memoryLowPath = "$cgroupPath/$MEMORY_LOW"
-        val value = if (it == -1L) "max" else it.toString()
-        writeCgroupFile(fs, memoryLowPath, value, "memory.low")
-    }
-
-    // Set memory.swap.max (swap limit)
-    swap?.let { swapValue ->
-        limit?.let { limitValue ->
-            val memorySwapPath = "$cgroupPath/$MEMORY_SWAP_MAX"
-            // In cgroup v2, swap is separate from memory (unlike v1 where swap was memory+swap)
-            // So if swap=2048 and limit=1024, we write 2048-1024=1024 to memory.swap.max
-            val value =
-                when {
-                    swapValue == -1L || limitValue == -1L -> "max"
-                    else -> (swapValue - limitValue).toString()
-                }
-            writeCgroupFile(fs, memorySwapPath, value, "memory.swap.max")
-        }
-    }
-}
-
-/**
- * Apply CPU resource limits
- */
-@OptIn(ExperimentalForeignApi::class)
-private fun applyCpuLimits(
-    fs: FileSystem,
-    cgroupPath: String,
-    shares: Long?,
-    quota: Long?,
-    period: Long?,
-) {
-    // Convert shares to cpu.weight (cgroup v1 shares -> cgroup v2 weight conversion)
-    // Formula: weight = 1 + ((shares - 2) * 9999) / 262142
-    shares?.let {
-        if (it > 0) {
-            val weight =
-                if (it == 0L) {
-                    0L
-                } else {
-                    val w = 1L + ((it - 2) * 9999 / 262142)
-                    minOf(w, 10000L) // MAX_CPU_WEIGHT = 10000
-                }
-            if (weight != 0L) {
-                val cpuWeightPath = "$cgroupPath/$CPU_WEIGHT"
-                writeCgroupFile(fs, cpuWeightPath, weight.toString(), "cpu.weight")
-            }
-        }
-    }
-
-    // Set cpu.max (format: "quota period")
-    if (quota != null || period != null) {
-        val cpuMaxPath = "$cgroupPath/$CPU_MAX"
-        val quotaStr =
-            when {
-                quota == null -> null
-                quota <= 0 -> "max"
-                else -> quota.toString()
-            }
-        val periodStr = period?.toString()
-
-        val value =
-            when {
-                quotaStr != null && periodStr != null -> "$quotaStr $periodStr"
-                quotaStr != null -> quotaStr
-                periodStr != null -> "max $periodStr"
-                else -> null
-            }
-
-        value?.let {
-            writeCgroupFile(fs, cpuMaxPath, it, "cpu.max")
-        }
-    }
-}
-
-/**
- * Write value to a cgroup file
- */
-private fun writeCgroupFile(
-    fs: FileSystem,
-    path: String,
-    value: String,
-    name: String,
-) {
-    try {
-        fs.writeTextFile(path, value)
-        Logger.debug("set $name = $value")
-    } catch (e: Exception) {
-        Logger.warn("failed to write $name: ${e.message}")
-        // Warn-only because resource limits are best-effort
-    }
-}
-
-/**
- * Determine which controllers are required based on resource configuration
- */
-private fun getRequiredControllers(resources: LinuxResources?): List<String> {
-    if (resources == null) {
-        return emptyList()
-    }
-
-    val controllers = mutableListOf<String>()
-
-    // Memory controller needed if any memory limit is specified
-    if (resources.memory != null) {
-        controllers.add("memory")
-    }
-
-    // CPU controller needed if any CPU limit is specified
-    if (resources.cpu != null) {
-        controllers.add("cpu")
-    }
-
-    return controllers
-}
-
-/**
- * Cleanup cgroup for a container
- *
- * Removes the cgroup directory for the container.
- * Errors are logged as warnings and do not fail the operation.
- *
- * @param cgroupPath Relative path from /sys/fs/cgroup
- */
-@OptIn(ExperimentalForeignApi::class)
-fun cleanupCgroup(cgroupPath: String?) {
-    if (cgroupPath == null) {
-        Logger.debug("no cgroup path specified, skipping cleanup")
-        return
-    }
-
-    // Normalize cgroup path: remove leading slash if present
-    val normalizedPath = cgroupPath.removePrefix("/")
-    val fullPath = "$CGROUP_ROOT/$normalizedPath"
-    Logger.debug("cleaning up cgroup at $fullPath")
-
-    // Check if directory exists
-    if (access(fullPath, F_OK) != 0) {
-        Logger.debug("cgroup directory $fullPath does not exist, already cleaned up")
-        return
-    }
-
-    // Remove cgroup directory using rmdir
-    // Note: rmdir only works if the cgroup is empty (no processes)
-    val result = platform.posix.rmdir(fullPath)
-    if (result != 0) {
-        val errNum = platform.posix.errno
-        // Warn but don't fail - cgroup cleanup is best-effort
-        Logger.warn("failed to remove cgroup directory $fullPath: errno=$errNum")
-    } else {
-        Logger.debug("removed cgroup directory: $fullPath")
-    }
-}
-
-/**
- * Get list of PIDs in a cgroup
- *
- * Reads the cgroup.procs file and returns a list of process IDs.
- * This is used by the ps command to list processes in a container.
- *
- * @param cgroupPath Relative path from /sys/fs/cgroup (e.g., "mycontainer")
- * @return List of PIDs in the cgroup
- * @throws Exception if cgroup.procs file cannot be read
- */
-@OptIn(ExperimentalForeignApi::class)
-fun getCgroupPids(
-    fs: FileSystem,
-    cgroupPath: String,
-): List<Int> {
-    // Normalize cgroup path: remove leading slash if present
-    val normalizedPath = cgroupPath.removePrefix("/")
-    val fullPath = "$CGROUP_ROOT/$normalizedPath"
-    val procsPath = "$fullPath/$CGROUP_PROCS"
-
-    Logger.debug("reading PIDs from $procsPath")
-
-    val content =
-        try {
-            fs.readProcFile(procsPath)
-        } catch (e: Exception) {
-            Logger.error("failed to read cgroup.procs: ${e.message}")
-            throw Exception("Failed to read cgroup.procs file: ${e.message}")
-        }
-
-    // Parse PIDs from content (one PID per line)
-    val pids =
-        content
-            .trim()
-            .split("\n")
-            .filter { it.isNotBlank() }
-            .mapNotNull { line ->
-                line.trim().toIntOrNull()?.also {
-                    Logger.debug("found PID: $it")
-                }
-            }
-
-    Logger.debug("found ${pids.size} PIDs in cgroup")
-    return pids
+    /**
+     * Read the PIDs in the cgroup at [cgroupPath] from cgroup.procs.
+     */
+    fun getPids(cgroupPath: String): List<Int>
 }

--- a/src/nativeMain/kotlin/cgroup/CgroupV2.kt
+++ b/src/nativeMain/kotlin/cgroup/CgroupV2.kt
@@ -1,0 +1,253 @@
+package cgroup
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.memScoped
+import logger.Logger
+import spec.LinuxResources
+import utils.FileSystem
+
+/**
+ * cgroup v2 implementation backed by cgroupfs writes via [FileSystem].
+ */
+@OptIn(ExperimentalForeignApi::class)
+class CgroupV2(
+    private val fs: FileSystem,
+) : Cgroup {
+    override fun setup(
+        pid: Int,
+        cgroupPath: String?,
+        resources: LinuxResources?,
+    ) {
+        if (cgroupPath == null && resources == null) {
+            return
+        }
+
+        memScoped {
+            // Normalize cgroup path: remove leading slash if present (containerd
+            // passes absolute paths)
+            val normalizedPath = cgroupPath?.removePrefix("/") ?: "kontainer-$pid"
+            val fullPath = "$CGROUP_ROOT/$normalizedPath"
+
+            Logger.debug("setting up cgroup at $fullPath")
+
+            fs.createDirectories(fullPath, 0x1EDu) // 0o755
+            Logger.debug("created cgroup directory: $fullPath")
+
+            // Enable controllers at every ancestor of the leaf cgroup.
+            // In cgroup v2 a controller is only available in a child cgroup if its
+            // parent's cgroup.subtree_control contains +<controller>. For a nested
+            // path like "default/test-verify" we must enable controllers in both
+            // /sys/fs/cgroup/cgroup.subtree_control and
+            // /sys/fs/cgroup/default/cgroup.subtree_control, otherwise opening
+            // memory.max etc. in the leaf fails with EACCES.
+            val requiredControllers = getRequiredControllers(resources)
+            if (requiredControllers.isNotEmpty()) {
+                val segments = normalizedPath.split("/").filter { it.isNotEmpty() }
+                val ancestorPaths = mutableListOf(CGROUP_ROOT)
+                for (i in 0 until segments.size - 1) {
+                    ancestorPaths.add("${ancestorPaths.last()}/${segments[i]}")
+                }
+
+                for (ancestorPath in ancestorPaths) {
+                    val subtreeControlPath = "$ancestorPath/$CGROUP_SUBTREE_CONTROL"
+                    for (controller in requiredControllers) {
+                        try {
+                            fs.writeTextFile(subtreeControlPath, "+$controller")
+                            Logger.debug("enabled $controller controller in $ancestorPath")
+                        } catch (e: Exception) {
+                            Logger.error("failed to enable $controller controller in $ancestorPath: ${e.message}")
+                            throw Exception("Failed to enable required cgroup controller: $controller in $ancestorPath", e)
+                        }
+                    }
+                }
+            }
+
+            val procsPath = "$fullPath/$CGROUP_PROCS"
+            try {
+                fs.writeTextFile(procsPath, pid.toString())
+                Logger.debug("added PID $pid to cgroup")
+            } catch (e: Exception) {
+                Logger.error("failed to add PID to cgroup: ${e.message}")
+                throw Exception("Failed to add PID to cgroup", e)
+            }
+
+            if (resources != null) {
+                applyResources(fullPath, resources)
+            }
+        }
+    }
+
+    override fun cleanup(cgroupPath: String?) {
+        if (cgroupPath == null) {
+            Logger.debug("no cgroup path specified, skipping cleanup")
+            return
+        }
+
+        val normalizedPath = cgroupPath.removePrefix("/")
+        val fullPath = "$CGROUP_ROOT/$normalizedPath"
+        Logger.debug("cleaning up cgroup at $fullPath")
+
+        // removeDirectory returns false on missing directory or error; in either
+        // case cleanup is best-effort and we already log inside the impl.
+        fs.removeDirectory(fullPath)
+    }
+
+    override fun getPids(cgroupPath: String): List<Int> {
+        val normalizedPath = cgroupPath.removePrefix("/")
+        val fullPath = "$CGROUP_ROOT/$normalizedPath"
+        val procsPath = "$fullPath/$CGROUP_PROCS"
+
+        Logger.debug("reading PIDs from $procsPath")
+
+        val content =
+            try {
+                fs.readProcFile(procsPath)
+            } catch (e: Exception) {
+                Logger.error("failed to read cgroup.procs: ${e.message}")
+                throw Exception("Failed to read cgroup.procs file: ${e.message}")
+            }
+
+        val pids =
+            content
+                .trim()
+                .split("\n")
+                .filter { it.isNotBlank() }
+                .mapNotNull { line ->
+                    line.trim().toIntOrNull()?.also {
+                        Logger.debug("found PID: $it")
+                    }
+                }
+
+        Logger.debug("found ${pids.size} PIDs in cgroup")
+        return pids
+    }
+
+    private fun applyResources(
+        cgroupPath: String,
+        resources: LinuxResources,
+    ) {
+        resources.memory?.let { memory ->
+            applyMemoryLimits(cgroupPath, memory.limit, memory.reservation, memory.swap)
+        }
+        resources.cpu?.let { cpu ->
+            applyCpuLimits(cgroupPath, cpu.shares, cpu.quota, cpu.period)
+        }
+    }
+
+    private fun applyMemoryLimits(
+        cgroupPath: String,
+        limit: Long?,
+        reservation: Long?,
+        swap: Long?,
+    ) {
+        limit?.let {
+            val memoryMaxPath = "$cgroupPath/$MEMORY_MAX"
+            val value = if (it == -1L) "max" else it.toString()
+            writeCgroupFile(memoryMaxPath, value, "memory.max")
+        }
+
+        reservation?.let {
+            val memoryLowPath = "$cgroupPath/$MEMORY_LOW"
+            val value = if (it == -1L) "max" else it.toString()
+            writeCgroupFile(memoryLowPath, value, "memory.low")
+        }
+
+        // In cgroup v2 swap is separate from memory (unlike v1 where swap was
+        // memory+swap), so swap.max receives swap minus the limit.
+        swap?.let { swapValue ->
+            limit?.let { limitValue ->
+                val memorySwapPath = "$cgroupPath/$MEMORY_SWAP_MAX"
+                val value =
+                    when {
+                        swapValue == -1L || limitValue == -1L -> "max"
+                        else -> (swapValue - limitValue).toString()
+                    }
+                writeCgroupFile(memorySwapPath, value, "memory.swap.max")
+            }
+        }
+    }
+
+    private fun applyCpuLimits(
+        cgroupPath: String,
+        shares: Long?,
+        quota: Long?,
+        period: Long?,
+    ) {
+        // Convert cgroup v1 shares to cgroup v2 weight
+        // Formula: weight = 1 + ((shares - 2) * 9999) / 262142
+        shares?.let {
+            if (it > 0) {
+                val weight =
+                    if (it == 0L) {
+                        0L
+                    } else {
+                        val w = 1L + ((it - 2) * 9999 / 262142)
+                        minOf(w, 10000L) // MAX_CPU_WEIGHT
+                    }
+                if (weight != 0L) {
+                    val cpuWeightPath = "$cgroupPath/$CPU_WEIGHT"
+                    writeCgroupFile(cpuWeightPath, weight.toString(), "cpu.weight")
+                }
+            }
+        }
+
+        // Set cpu.max (format: "quota period")
+        if (quota != null || period != null) {
+            val cpuMaxPath = "$cgroupPath/$CPU_MAX"
+            val quotaStr =
+                when {
+                    quota == null -> null
+                    quota <= 0 -> "max"
+                    else -> quota.toString()
+                }
+            val periodStr = period?.toString()
+
+            val value =
+                when {
+                    quotaStr != null && periodStr != null -> "$quotaStr $periodStr"
+                    quotaStr != null -> quotaStr
+                    periodStr != null -> "max $periodStr"
+                    else -> null
+                }
+
+            value?.let {
+                writeCgroupFile(cpuMaxPath, it, "cpu.max")
+            }
+        }
+    }
+
+    private fun writeCgroupFile(
+        path: String,
+        value: String,
+        name: String,
+    ) {
+        try {
+            fs.writeTextFile(path, value)
+            Logger.debug("set $name = $value")
+        } catch (e: Exception) {
+            // Warn-only because resource limits are best-effort
+            Logger.warn("failed to write $name: ${e.message}")
+        }
+    }
+
+    private fun getRequiredControllers(resources: LinuxResources?): List<String> {
+        if (resources == null) {
+            return emptyList()
+        }
+        val controllers = mutableListOf<String>()
+        if (resources.memory != null) controllers.add("memory")
+        if (resources.cpu != null) controllers.add("cpu")
+        return controllers
+    }
+
+    companion object {
+        private const val CGROUP_ROOT = "/sys/fs/cgroup"
+        private const val CGROUP_PROCS = "cgroup.procs"
+        private const val CGROUP_SUBTREE_CONTROL = "cgroup.subtree_control"
+        private const val MEMORY_MAX = "memory.max"
+        private const val MEMORY_LOW = "memory.low"
+        private const val MEMORY_SWAP_MAX = "memory.swap.max"
+        private const val CPU_WEIGHT = "cpu.weight"
+        private const val CPU_MAX = "cpu.max"
+    }
+}

--- a/src/nativeMain/kotlin/command/Create.kt
+++ b/src/nativeMain/kotlin/command/Create.kt
@@ -1,5 +1,6 @@
 package command
 
+import cgroup.Cgroup
 import channel.NotifyListener
 import channel.initChannel
 import channel.mainChannel
@@ -26,6 +27,7 @@ import utils.FileSystem
 fun create(
     syscall: Syscall,
     fs: FileSystem,
+    cgroup: Cgroup,
     rootPath: String,
     containerId: String,
     bundlePath: String = ".",
@@ -186,6 +188,7 @@ fun create(
                 runMainProcess(
                     syscall = syscall,
                     fs = fs,
+                    cgroup = cgroup,
                     stage1Pid = stage1Pid,
                     syncFd = syncFds[0],
                     spec = spec,

--- a/src/nativeMain/kotlin/command/Delete.kt
+++ b/src/nativeMain/kotlin/command/Delete.kt
@@ -1,6 +1,6 @@
 package command
 
-import cgroup.cleanupCgroup
+import cgroup.Cgroup
 import config.loadKontainerConfig
 import kotlinx.cinterop.ExperimentalForeignApi
 import logger.Logger
@@ -21,6 +21,7 @@ import utils.FileSystem
 fun delete(
     syscall: Syscall,
     fs: FileSystem,
+    cgroup: Cgroup,
     rootPath: String,
     containerId: String,
     force: Boolean = false,
@@ -99,7 +100,7 @@ fun delete(
     // Cleanup cgroup
     config?.cgroupPath?.let { cgroupPath ->
         try {
-            cleanupCgroup(cgroupPath)
+            cgroup.cleanup(cgroupPath)
         } catch (e: Exception) {
             Logger.warn("failed to cleanup cgroup: ${e.message ?: "unknown"}")
             // Continue with deletion even if cgroup cleanup fails

--- a/src/nativeMain/kotlin/command/Ps.kt
+++ b/src/nativeMain/kotlin/command/Ps.kt
@@ -1,6 +1,6 @@
 package command
 
-import cgroup.getCgroupPids
+import cgroup.Cgroup
 import config.loadKontainerConfig
 import kotlinx.cinterop.*
 import logger.Logger
@@ -21,6 +21,7 @@ import utils.JsonCodec
 @OptIn(ExperimentalForeignApi::class)
 fun ps(
     fs: FileSystem,
+    cgroup: Cgroup,
     rootPath: String,
     containerId: String,
     format: String = "json",
@@ -69,7 +70,7 @@ fun ps(
     // Get PIDs from cgroup
     val pids =
         try {
-            getCgroupPids(fs, cgroupPath)
+            cgroup.getPids(cgroupPath)
         } catch (e: Exception) {
             Logger.error("failed to get container PIDs: ${e.message ?: "unknown"}")
             exit(1)

--- a/src/nativeMain/kotlin/process/MainProcess.kt
+++ b/src/nativeMain/kotlin/process/MainProcess.kt
@@ -1,6 +1,6 @@
 package process
 
-import cgroup.setupCgroup
+import cgroup.Cgroup
 import channel.*
 import config.KontainerConfig
 import config.saveKontainerConfig
@@ -39,6 +39,7 @@ import utils.FileSystem
 private fun runMainProcessInternal(
     syscall: Syscall,
     fs: FileSystem,
+    cgroup: Cgroup,
     stage1Pid: Int,
     syncFd: Int,
     spec: Spec,
@@ -58,7 +59,7 @@ private fun runMainProcessInternal(
 
         // Setup cgroup for Stage-1 BEFORE syncing with child
         // Stage-1 → Stage-2 are both included in the cgroup (inherited through fork)
-        setupCgroup(fs, stage1Pid, spec.linux?.cgroupsPath, spec.linux?.resources)
+        cgroup.setup(stage1Pid, spec.linux?.cgroupsPath, spec.linux?.resources)
 
         // Apply rlimits to Stage-1 BEFORE entering user namespace
         // Rlimits are inherited: Stage-1 → Stage-2
@@ -222,6 +223,7 @@ private fun runMainProcessInternal(
 fun runMainProcess(
     syscall: Syscall,
     fs: FileSystem,
+    cgroup: Cgroup,
     stage1Pid: Int,
     syncFd: Int,
     spec: Spec,
@@ -239,6 +241,7 @@ fun runMainProcess(
         runMainProcessInternal(
             syscall,
             fs,
+            cgroup,
             stage1Pid,
             syncFd,
             spec,

--- a/src/nativeMain/kotlin/utils/FileSystem.kt
+++ b/src/nativeMain/kotlin/utils/FileSystem.kt
@@ -46,4 +46,11 @@ interface FileSystem {
      * Returns true if [path] exists and can be opened.
      */
     fun fileExists(path: String): Boolean
+
+    /**
+     * Remove an empty directory. Returns true if removed, false if it did not exist.
+     * Other errors (e.g. directory not empty, permission denied) are logged as a
+     * warning by the implementation but not thrown.
+     */
+    fun removeDirectory(path: String): Boolean
 }

--- a/src/nativeMain/kotlin/utils/RealFileSystem.kt
+++ b/src/nativeMain/kotlin/utils/RealFileSystem.kt
@@ -184,4 +184,22 @@ class RealFileSystem : FileSystem {
         Logger.debug("file does not exist: $path")
         return false
     }
+
+    override fun removeDirectory(path: String): Boolean {
+        if (access(path, F_OK) != 0) {
+            Logger.debug("directory $path does not exist, nothing to remove")
+            return false
+        }
+
+        if (rmdir(path) != 0) {
+            val errNum = errno
+            // Best-effort: cleanup callers (cgroup, container dir) tolerate non-empty
+            // directories or permission errors silently.
+            Logger.warn("failed to remove directory $path: errno=$errNum")
+            return false
+        }
+
+        Logger.debug("removed directory: $path")
+        return true
+    }
 }

--- a/src/nativeTest/kotlin/cgroup/CgroupTest.kt
+++ b/src/nativeTest/kotlin/cgroup/CgroupTest.kt
@@ -12,60 +12,52 @@ import utils.FakeFileSystem
 class CgroupTest :
     FunSpec({
 
-        // setupCgroup: subtree_control propagation across all ancestors
+        // setup: subtree_control propagation across all ancestors
         // (the bug fixed in PR #17 — must enable controllers at every parent
         // of the leaf, not just root, otherwise leaf opens fail with EACCES)
 
-        test("setupCgroup enables controllers at every ancestor for nested cgroupsPath") {
+        test("setup enables controllers at every ancestor for nested cgroupsPath") {
             val fs = FakeFileSystem()
-            setupCgroup(
-                fs,
+            CgroupV2(fs).setup(
                 pid = 1234,
                 cgroupPath = "default/test-verify",
                 resources = LinuxResources(memory = LinuxMemory(limit = 134217728L)),
             )
 
-            // Leaf cgroup directory created
             fs.directories shouldContain "/sys/fs/cgroup/default/test-verify"
 
-            // Controllers enabled at root AND at the parent of the leaf
             fs.files["/sys/fs/cgroup/cgroup.subtree_control"] shouldBe "+memory"
             fs.files["/sys/fs/cgroup/default/cgroup.subtree_control"] shouldBe "+memory"
 
-            // Process placed in the leaf cgroup
             fs.files["/sys/fs/cgroup/default/test-verify/cgroup.procs"] shouldBe "1234"
-
-            // Memory limit applied to leaf
             fs.files["/sys/fs/cgroup/default/test-verify/memory.max"] shouldBe "134217728"
         }
 
-        test("setupCgroup enables controllers only at root for top-level cgroupsPath") {
+        test("setup enables controllers only at root for top-level cgroupsPath") {
             val fs = FakeFileSystem()
-            setupCgroup(
-                fs,
+            CgroupV2(fs).setup(
                 pid = 42,
                 cgroupPath = "kontainer-42",
                 resources = LinuxResources(memory = LinuxMemory(limit = 1024L)),
             )
 
             fs.files["/sys/fs/cgroup/cgroup.subtree_control"] shouldBe "+memory"
-            // No intermediate parent — only the root level needs +memory
+            // No intermediate parent — only root needs +memory
             fs.files.keys shouldNotContain "/sys/fs/cgroup/kontainer-42/cgroup.subtree_control"
             fs.files["/sys/fs/cgroup/kontainer-42/memory.max"] shouldBe "1024"
         }
 
-        test("setupCgroup short-circuits when both cgroupPath and resources are null") {
+        test("setup short-circuits when both cgroupPath and resources are null") {
             val fs = FakeFileSystem()
-            setupCgroup(fs, pid = 1, cgroupPath = null, resources = null)
+            CgroupV2(fs).setup(pid = 1, cgroupPath = null, resources = null)
             fs.calls.isEmpty() shouldBe true
         }
 
         // Resource value translation
 
-        test("setupCgroup writes 'max' for limit = -1") {
+        test("setup writes 'max' for limit = -1") {
             val fs = FakeFileSystem()
-            setupCgroup(
-                fs,
+            CgroupV2(fs).setup(
                 pid = 1,
                 cgroupPath = "x",
                 resources = LinuxResources(memory = LinuxMemory(limit = -1L)),
@@ -73,10 +65,9 @@ class CgroupTest :
             fs.files["/sys/fs/cgroup/x/memory.max"] shouldBe "max"
         }
 
-        test("setupCgroup writes cpu.max as 'quota period' when both are set") {
+        test("setup writes cpu.max as 'quota period' when both are set") {
             val fs = FakeFileSystem()
-            setupCgroup(
-                fs,
+            CgroupV2(fs).setup(
                 pid = 1,
                 cgroupPath = "x",
                 resources = LinuxResources(cpu = LinuxCpu(quota = 50000L, period = 100000L)),
@@ -84,10 +75,9 @@ class CgroupTest :
             fs.files["/sys/fs/cgroup/x/cpu.max"] shouldBe "50000 100000"
         }
 
-        test("setupCgroup writes cpu.max as 'max' when quota is non-positive") {
+        test("setup writes cpu.max as 'max' when quota is non-positive") {
             val fs = FakeFileSystem()
-            setupCgroup(
-                fs,
+            CgroupV2(fs).setup(
                 pid = 1,
                 cgroupPath = "x",
                 resources = LinuxResources(cpu = LinuxCpu(quota = -1L, period = 100000L)),
@@ -95,11 +85,10 @@ class CgroupTest :
             fs.files["/sys/fs/cgroup/x/cpu.max"] shouldBe "max 100000"
         }
 
-        test("setupCgroup converts cgroup v1 shares to v2 cpu.weight") {
+        test("setup converts cgroup v1 shares to v2 cpu.weight") {
             val fs = FakeFileSystem()
             // shares=1024 → weight = 1 + ((1024 - 2) * 9999) / 262142 = 1 + 38.99 ~ 39
-            setupCgroup(
-                fs,
+            CgroupV2(fs).setup(
                 pid = 1,
                 cgroupPath = "x",
                 resources = LinuxResources(cpu = LinuxCpu(shares = 1024L)),
@@ -107,10 +96,9 @@ class CgroupTest :
             fs.files["/sys/fs/cgroup/x/cpu.weight"] shouldBe "39"
         }
 
-        test("setupCgroup writes memory.swap.max as swap minus limit (cgroup v2 semantics)") {
+        test("setup writes memory.swap.max as swap minus limit (cgroup v2 semantics)") {
             val fs = FakeFileSystem()
-            setupCgroup(
-                fs,
+            CgroupV2(fs).setup(
                 pid = 1,
                 cgroupPath = "x",
                 resources = LinuxResources(memory = LinuxMemory(limit = 1024L, swap = 2048L)),
@@ -118,26 +106,50 @@ class CgroupTest :
             fs.files["/sys/fs/cgroup/x/memory.swap.max"] shouldBe "1024"
         }
 
-        // getCgroupPids
+        // getPids
 
-        test("getCgroupPids returns the PIDs read from cgroup.procs") {
+        test("getPids returns the PIDs read from cgroup.procs") {
             val fs = FakeFileSystem()
             fs.files["/sys/fs/cgroup/x/cgroup.procs"] = "100\n200\n300\n"
 
-            getCgroupPids(fs, "x") shouldBe listOf(100, 200, 300)
+            CgroupV2(fs).getPids("x") shouldBe listOf(100, 200, 300)
         }
 
-        test("getCgroupPids accepts a leading slash in the path") {
+        test("getPids accepts a leading slash in the path") {
             val fs = FakeFileSystem()
             fs.files["/sys/fs/cgroup/x/cgroup.procs"] = "1\n"
 
-            getCgroupPids(fs, "/x") shouldBe listOf(1)
+            CgroupV2(fs).getPids("/x") shouldBe listOf(1)
         }
 
-        test("getCgroupPids skips blank and non-numeric lines") {
+        test("getPids skips blank and non-numeric lines") {
             val fs = FakeFileSystem()
             fs.files["/sys/fs/cgroup/x/cgroup.procs"] = "1\n\nabc\n2\n"
 
-            getCgroupPids(fs, "x") shouldBe listOf(1, 2)
+            CgroupV2(fs).getPids("x") shouldBe listOf(1, 2)
+        }
+
+        // cleanup
+
+        test("cleanup is a no-op for null path") {
+            val fs = FakeFileSystem()
+            CgroupV2(fs).cleanup(null)
+            fs.calls.isEmpty() shouldBe true
+        }
+
+        test("cleanup removes the directory when present") {
+            val fs = FakeFileSystem()
+            fs.directories += "/sys/fs/cgroup/x"
+
+            CgroupV2(fs).cleanup("x")
+
+            ("/sys/fs/cgroup/x" in fs.directories) shouldBe false
+        }
+
+        test("cleanup tolerates missing directory") {
+            val fs = FakeFileSystem()
+            CgroupV2(fs).cleanup("never-existed")
+            // Did not throw; the FakeFileSystem just returns false for the remove
+            ("/sys/fs/cgroup/never-existed" in fs.directories) shouldBe false
         }
     })

--- a/src/nativeTest/kotlin/cgroup/FakeCgroup.kt
+++ b/src/nativeTest/kotlin/cgroup/FakeCgroup.kt
@@ -1,0 +1,31 @@
+package cgroup
+
+import spec.LinuxResources
+
+/**
+ * In-memory [Cgroup] for tests of higher layers (Create / Delete / Ps).
+ *
+ * Records every call as a string. [getPids] returns whatever a test
+ * preseeds via [pidsByPath]; missing paths return an empty list.
+ */
+class FakeCgroup : Cgroup {
+    val calls: MutableList<String> = mutableListOf()
+    val pidsByPath: MutableMap<String, List<Int>> = mutableMapOf()
+
+    override fun setup(
+        pid: Int,
+        cgroupPath: String?,
+        resources: LinuxResources?,
+    ) {
+        calls += "setup(pid=$pid, cgroupPath=$cgroupPath, hasResources=${resources != null})"
+    }
+
+    override fun cleanup(cgroupPath: String?) {
+        calls += "cleanup(cgroupPath=$cgroupPath)"
+    }
+
+    override fun getPids(cgroupPath: String): List<Int> {
+        calls += "getPids(cgroupPath=$cgroupPath)"
+        return pidsByPath[cgroupPath] ?: emptyList()
+    }
+}

--- a/src/nativeTest/kotlin/utils/FakeFileSystem.kt
+++ b/src/nativeTest/kotlin/utils/FakeFileSystem.kt
@@ -52,4 +52,9 @@ class FakeFileSystem : FileSystem {
         calls += "fileExists($path)"
         return path in files || path in directories
     }
+
+    override fun removeDirectory(path: String): Boolean {
+        calls += "removeDirectory($path)"
+        return directories.remove(path)
+    }
 }


### PR DESCRIPTION
## Summary

Same pattern as the [Syscall](src/nativeMain/kotlin/syscall/Syscall.kt) ([#19](https://github.com/ternbusty/kontainer-runtime/pull/19) / [#20](https://github.com/ternbusty/kontainer-runtime/pull/20)) and [FileSystem](src/nativeMain/kotlin/utils/FileSystem.kt) ([#22](https://github.com/ternbusty/kontainer-runtime/pull/22)) refactors but for the cgroup operations.

- New [src/nativeMain/kotlin/cgroup/Cgroup.kt](src/nativeMain/kotlin/cgroup/Cgroup.kt) interface with `setup` / `cleanup` / `getPids`.
- New [src/nativeMain/kotlin/cgroup/CgroupV2.kt](src/nativeMain/kotlin/cgroup/CgroupV2.kt) is the cgroupfs-backed implementation, holds `FileSystem` in its constructor. Preserves the existing logic verbatim — the subtree_control ancestor walk ([#17](https://github.com/ternbusty/kontainer-runtime/pull/17) fix), v1-shares-to-v2-weight conversion, `swap.max = swap - limit` semantic.
- [utils/FileSystem.kt](src/nativeMain/kotlin/utils/FileSystem.kt) gains `removeDirectory(path: String): Boolean` so cgroup cleanup can stop calling `platform.posix.rmdir/access` directly. `RealFileSystem` implements it via posix `rmdir`; `FakeFileSystem` mutates its in-memory `directories` set.
- `Main.kt` instantiates `CgroupV2(fs)` once and threads it into `create` / `delete` / `ps`. `start` / `kill` / `state` don't need it.

## Tests

- [cgroup/CgroupTest.kt](src/nativeTest/kotlin/cgroup/CgroupTest.kt) is migrated from `setupCgroup(fs, ...)` to `CgroupV2(fs).setup(...)`. Three new `cleanup` tests cover the null-path no-op and `FakeFileSystem`-backed directory removal.
- [cgroup/FakeCgroup.kt](src/nativeTest/kotlin/cgroup/FakeCgroup.kt) (new) records every call. It's available for the next round of higher-layer tests (e.g. asserting that `delete` invokes `cgroup.cleanup` for the right path).

## Test plan

- [ ] `build` workflow passes (compile + ktlint + kotest, including the migrated cgroup tests)
- [ ] `integration` workflow still passes — production-side this is a name change plus indirection through `Cgroup` / `CgroupV2`; the actual cgroupfs operations are unchanged