### PR TITLE
refactor: introduce Channel and Notify interfaces with socket-backed impls

### DIFF
--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -1,8 +1,8 @@
 import bootstrap.kontainer_is_init_process
 import cgroup.CgroupV2
-import channel.InitReceiver
-import channel.MainSender
-import channel.NotifyListener
+import channel.SocketInitReceiver
+import channel.SocketMainSender
+import channel.SocketNotifyListener
 import command.*
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.memScoped
@@ -86,9 +86,9 @@ fun main(args: Array<String>): Unit =
                 }
 
             // Recreate channel objects from FDs (inherited from parent process)
-            val mainSender = MainSender(mainSenderFd)
-            val initReceiver = InitReceiver(initReceiverFd)
-            val notifyListener = NotifyListener(notifyListenerFd)
+            val mainSender = SocketMainSender(mainSenderFd)
+            val initReceiver = SocketInitReceiver(initReceiverFd)
+            val notifyListener = SocketNotifyListener(notifyListenerFd)
 
             val pid = getpid()
             Logger.info("init process (Stage-2, PID=$pid) started successfully via bootstrap.c")

--- a/src/nativeMain/kotlin/channel/Channel.kt
+++ b/src/nativeMain/kotlin/channel/Channel.kt
@@ -1,307 +1,70 @@
 package channel
 
-import kotlinx.cinterop.*
-import platform.linux.*
-import platform.posix.*
-import utils.JsonCodec
-
 /*
- * Each of the main, intermediate, and init process will have a uni-directional
- * channel (a sender and a receiver). Each process will hold the receiver and
- * listen message on it. Each sender is shared between processes to send
- * message to the corresponding receiver.
+ * Each of the main and init processes holds one receiver and shares the
+ * matching sender across processes via the FDs inherited at exec time.
+ *
+ * The interfaces below are the testability seam; concrete socket-backed
+ * implementations live in SocketChannel.kt. Tests inject fakes that record
+ * sent messages and let tests preseed received ones.
  */
 
 /**
- * Base channel implementation using socketpair
+ * Sender side of the main channel (init -> main).
  */
-@OptIn(ExperimentalForeignApi::class)
-private fun createSocketPair(): Pair<Int, Int> {
-    val sv = IntArray(2)
-    if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv.refTo(0)) != 0) {
-        perror("socketpair")
-        throw Exception("Failed to create socketpair")
-    }
-    return Pair(sv[0], sv[1])
+interface MainSender {
+    fun fd(): Int
+
+    fun identifierMappingRequest()
+
+    fun initReady()
+
+    fun seccompNotifyRequest(fd: Int)
+
+    fun execFailed(error: String)
+
+    fun sendError(error: String)
+
+    fun close()
 }
 
 /**
- * Send a message through a socket
+ * Receiver side of the main channel (init -> main).
  */
-@OptIn(ExperimentalForeignApi::class)
-private fun sendMessage(
-    socket: Int,
-    message: Message,
-) {
-    val json = JsonCodec.encode(message)
-    val bytes = json.encodeToByteArray()
+interface MainReceiver {
+    fun fd(): Int
 
-    memScoped {
-        val sent = send(socket, bytes.refTo(0), bytes.size.toULong(), 0)
-        if (sent == -1L) {
-            perror("send")
-            throw Exception("Failed to send message")
-        }
-    }
+    fun waitForMappingRequest(): Message.WriteMapping
+
+    fun waitForInitReady()
+
+    fun waitForSeccompRequest(): Int
+
+    fun close()
 }
 
 /**
- * Receive a message from a socket
+ * Sender side of the init channel (main -> init).
  */
-@OptIn(ExperimentalForeignApi::class)
-private fun receiveMessage(socket: Int): Message {
-    memScoped {
-        val buffer = allocArray<ByteVar>(4096)
-        val received = recv(socket, buffer, 4095.toULong(), 0)
+interface InitSender {
+    fun fd(): Int
 
-        if (received == -1L) {
-            perror("recv")
-            throw Exception("Failed to receive message")
-        }
-        if (received == 0L) {
-            throw Exception("Connection closed")
-        }
+    fun mappingWritten()
 
-        buffer[received.toInt()] = 0
-        val json = buffer.toKString()
-        return JsonCodec.decode<Message>(json)
-    }
+    fun seccompNotifyDone()
+
+    fun close()
 }
 
 /**
- * Send a message with a file descriptor using SCM_RIGHTS
+ * Receiver side of the init channel (main -> init).
  */
-@OptIn(ExperimentalForeignApi::class)
-private fun sendMessageWithFd(
-    socket: Int,
-    message: Message,
-    fd: Int,
-) {
-    val json = JsonCodec.encode(message)
-    val bytes = json.encodeToByteArray()
+interface InitReceiver {
+    fun fd(): Int
 
-    memScoped {
-        // Prepare iovec for message data
-        val iov = alloc<iovec>()
-        iov.iov_base = bytes.refTo(0).getPointer(this)
-        iov.iov_len = bytes.size.toULong()
+    fun waitForMappingAck()
 
-        // Prepare control message (cmsg) for file descriptor
-        val cmsgSpace = _CMSG_SPACE(sizeOf<IntVar>().toULong())
-        val cmsgBuf = allocArray<ByteVar>(cmsgSpace.toInt())
+    fun waitForSeccompRequestDone()
 
-        // Prepare msghdr
-        val msg = alloc<msghdr>()
-        msg.msg_name = null
-        msg.msg_namelen = 0u
-        msg.msg_iov = iov.ptr
-        msg.msg_iovlen = 1u
-        msg.msg_control = cmsgBuf
-        msg.msg_controllen = cmsgSpace
-        msg.msg_flags = 0
-
-        // Set up control message header
-        val cmsg = _CMSG_FIRSTHDR(msg.ptr)
-        if (cmsg != null) {
-            cmsg.pointed.cmsg_level = SOL_SOCKET
-            cmsg.pointed.cmsg_type = SCM_RIGHTS
-            cmsg.pointed.cmsg_len = _CMSG_LEN(sizeOf<IntVar>().toULong())
-
-            // Copy file descriptor into control message data
-            val dataPtr = _CMSG_DATA(cmsg)
-            if (dataPtr != null) {
-                dataPtr.reinterpret<IntVar>().pointed.value = fd
-            }
-        }
-
-        val sent = sendmsg(socket, msg.ptr, 0)
-        if (sent == -1L) {
-            perror("sendmsg")
-            throw Exception("Failed to send message with FD")
-        }
-    }
-}
-
-/**
- * Receive a message with a file descriptor using SCM_RIGHTS
- */
-@OptIn(ExperimentalForeignApi::class)
-private fun receiveMessageWithFd(socket: Int): Pair<Message, Int> {
-    memScoped {
-        // Prepare buffer for message data
-        val buffer = allocArray<ByteVar>(4096)
-        val iov = alloc<iovec>()
-        iov.iov_base = buffer
-        iov.iov_len = 4095u
-
-        // Prepare buffer for control message
-        val cmsgSpace = _CMSG_SPACE(sizeOf<IntVar>().toULong())
-        val cmsgBuf = allocArray<ByteVar>(cmsgSpace.toInt())
-
-        // Prepare msghdr
-        val msg = alloc<msghdr>()
-        msg.msg_name = null
-        msg.msg_namelen = 0u
-        msg.msg_iov = iov.ptr
-        msg.msg_iovlen = 1u
-        msg.msg_control = cmsgBuf
-        msg.msg_controllen = cmsgSpace
-        msg.msg_flags = 0
-
-        val received = recvmsg(socket, msg.ptr, 0)
-        if (received == -1L) {
-            perror("recvmsg")
-            throw Exception("Failed to receive message with FD")
-        }
-        if (received == 0L) {
-            throw Exception("Connection closed")
-        }
-
-        // Extract message data
-        buffer[received.toInt()] = 0
-        val json = buffer.toKString()
-        val message = JsonCodec.decode<Message>(json)
-
-        // Extract file descriptor from control message
-        var receivedFd = -1
-        val cmsg = _CMSG_FIRSTHDR(msg.ptr)
-
-        if (cmsg != null && cmsg.pointed.cmsg_level == SOL_SOCKET && cmsg.pointed.cmsg_type == SCM_RIGHTS) {
-            val dataPtr = _CMSG_DATA(cmsg)
-            if (dataPtr != null) {
-                receivedFd = dataPtr.reinterpret<IntVar>().pointed.value
-            }
-        }
-
-        if (receivedFd == -1) {
-            throw Exception("Failed to extract FD from control message")
-        }
-
-        return Pair(message, receivedFd)
-    }
-}
-
-/**
- * Main Channel - for communication from init to main process
- */
-class MainSender(
-    private val socket: Int,
-) {
-    fun fd(): Int = socket
-
-    fun identifierMappingRequest() {
-        sendMessage(socket, Message.WriteMapping)
-    }
-
-    fun initReady() {
-        sendMessage(socket, Message.InitReady)
-    }
-
-    fun seccompNotifyRequest(fd: Int) {
-        sendMessageWithFd(socket, Message.SeccompNotify, fd)
-    }
-
-    fun execFailed(error: String) {
-        sendMessage(socket, Message.ExecFailed(error))
-    }
-
-    fun sendError(error: String) {
-        sendMessage(socket, Message.OtherError(error))
-    }
-
-    fun close() {
-        close(socket)
-    }
-}
-
-class MainReceiver(
-    private val socket: Int,
-) {
-    fun fd(): Int = socket
-
-    fun waitForMappingRequest(): Message.WriteMapping =
-        when (val msg = receiveMessage(socket)) {
-            is Message.WriteMapping -> msg
-            is Message.ExecFailed -> throw Exception("Exec failed: ${msg.error}")
-            is Message.OtherError -> throw Exception("Error: ${msg.error}")
-            else -> throw Exception("Unexpected message: $msg, expected WriteMapping")
-        }
-
-    fun waitForInitReady() {
-        when (val msg = receiveMessage(socket)) {
-            is Message.InitReady -> return
-            is Message.ExecFailed -> throw Exception("Exec failed: ${msg.error}")
-            is Message.OtherError -> throw Exception("Error: ${msg.error}")
-            else -> throw Exception("Unexpected message: $msg, expected InitReady")
-        }
-    }
-
-    fun waitForSeccompRequest(): Int {
-        val (msg, fd) = receiveMessageWithFd(socket)
-        return when (msg) {
-            is Message.SeccompNotify -> fd
-            is Message.ExecFailed -> throw Exception("Exec failed: ${msg.error}")
-            is Message.OtherError -> throw Exception("Error: ${msg.error}")
-            else -> throw Exception("Unexpected message: $msg, expected SeccompNotify")
-        }
-    }
-
-    fun close() {
-        close(socket)
-    }
-}
-
-fun mainChannel(): Pair<MainSender, MainReceiver> {
-    val (sender, receiver) = createSocketPair()
-    return Pair(MainSender(sender), MainReceiver(receiver))
-}
-
-/**
- * Init Channel - for communication from main to init process
- */
-class InitSender(
-    private val socket: Int,
-) {
-    fun fd(): Int = socket
-
-    fun mappingWritten() {
-        sendMessage(socket, Message.MappingWritten)
-    }
-
-    fun seccompNotifyDone() {
-        sendMessage(socket, Message.SeccompNotifyDone)
-    }
-
-    fun close() {
-        close(socket)
-    }
-}
-
-class InitReceiver(
-    private val socket: Int,
-) {
-    fun fd(): Int = socket
-
-    fun waitForMappingAck() {
-        when (val msg = receiveMessage(socket)) {
-            is Message.MappingWritten -> return
-            else -> throw Exception("Unexpected message: $msg, expected MappingWritten")
-        }
-    }
-
-    fun waitForSeccompRequestDone() {
-        when (val msg = receiveMessage(socket)) {
-            is Message.SeccompNotifyDone -> return
-            else -> throw Exception("Unexpected message: $msg, expected SeccompNotifyDone")
-        }
-    }
-
-    fun close() {
-        close(socket)
-    }
-}
-
-fun initChannel(): Pair<InitSender, InitReceiver> {
-    val (sender, receiver) = createSocketPair()
-    return Pair(InitSender(sender), InitReceiver(receiver))
+    fun close()
 }

--- a/src/nativeMain/kotlin/channel/NotifySocket.kt
+++ b/src/nativeMain/kotlin/channel/NotifySocket.kt
@@ -6,47 +6,71 @@ import platform.linux.sockaddr_un
 import platform.posix.*
 
 /**
- * Notify Socket implementation for container start signaling
+ * Notify socket abstractions for container start signaling.
+ *
+ * The runtime uses a Unix domain socket. The init process (Stage-2) listens on
+ * it via [NotifyListener] and blocks in waitForContainerStart() until the
+ * `start` command connects via [NotifySocket] and sends a message.
+ *
+ * Implementations live in the same file because they're tightly coupled (they
+ * have to agree on the socket protocol).
  */
 
 const val NOTIFY_FILE = "notify.sock"
 
 /**
- * NotifyListener (server side) - created during container creation
- * Waits for start signal from the main process
+ * Server side of the notify socket. Owned by the init process (and inherited
+ * across exec via [fd]).
+ */
+interface NotifyListener {
+    /** FD of the listening socket; passed across exec via env vars. */
+    fun fd(): Int
+
+    /** Block until a client connects and sends a start message. */
+    fun waitForContainerStart()
+
+    fun close()
+}
+
+/**
+ * Client side of the notify socket. Used by the `start` command.
+ */
+interface NotifySocket {
+    /** Connect and send the start message. */
+    fun notifyContainerStart()
+}
+
+/**
+ * Unix-domain-socket-backed [NotifyListener].
+ *
+ * Two construction paths: from a path (creates socket, binds, listens) used by
+ * Create, and from an inherited FD used by the init process after fork/exec.
  */
 @OptIn(ExperimentalForeignApi::class)
-class NotifyListener {
+class SocketNotifyListener : NotifyListener {
     private val socket: Int
 
-    /**
-     * Constructor for creating a new socket (used by Create.kt)
-     */
     constructor(socketPath: String) {
         Logger.debug("NotifyListener: creating socket at $socketPath")
 
         memScoped {
-            // Create Unix domain socket
             socket = socket(AF_UNIX, SOCK_STREAM, 0)
             if (socket == -1) {
                 perror("socket")
                 throw Exception("Failed to create socket")
             }
 
-            // Unlink if exists
             unlink(socketPath)
 
-            // Bind to socket path
             val addr = alloc<sockaddr_un>()
             addr.sun_family = AF_UNIX.toUShort()
 
-            // Copy path to sun_path (limited to 108 bytes on Linux)
+            // sun_path is limited to 108 bytes on Linux
             val pathBytes = socketPath.encodeToByteArray()
             if (pathBytes.size >= 108) {
                 throw Exception("Socket path too long (max 108 bytes)")
             }
 
-            // Copy path into sun_path array
             for (i in pathBytes.indices) {
                 addr.sun_path[i] = pathBytes[i]
             }
@@ -61,7 +85,6 @@ class NotifyListener {
                 throw Exception("Failed to bind socket to $socketPath")
             }
 
-            // Listen for connections
             if (listen(socket, 1) == -1) {
                 perror("listen")
                 close(socket)
@@ -72,35 +95,23 @@ class NotifyListener {
         }
     }
 
-    /**
-     * Constructor for reusing an existing socket FD (used by init process after fork)
-     */
     constructor(fd: Int) {
         Logger.debug("NotifyListener: reusing existing socket fd=$fd")
         socket = fd
     }
 
-    /**
-     * Get the socket FD (for passing to child process)
-     */
-    fun fd(): Int = socket
+    override fun fd(): Int = socket
 
-    /**
-     * Wait for container start signal
-     * Blocks until a connection is accepted and message is received
-     */
-    fun waitForContainerStart() {
+    override fun waitForContainerStart() {
         memScoped {
             Logger.debug("NotifyListener: waiting for container start signal...")
 
-            // Accept connection
             val clientSocket = accept(socket, null, null)
             if (clientSocket == -1) {
                 perror("accept")
                 throw Exception("Failed to accept connection")
             }
 
-            // Read message
             val buffer = allocArray<ByteVar>(256)
             val n = recv(clientSocket, buffer, 255.toULong(), 0)
             if (n == -1L) {
@@ -118,31 +129,28 @@ class NotifyListener {
         }
     }
 
-    fun close() {
+    override fun close() {
         close(socket)
     }
 }
 
 /**
- * NotifySocket (client side) - used by start command
- * Sends start signal to the init process
+ * Unix-domain-socket-backed [NotifySocket].
  */
 @OptIn(ExperimentalForeignApi::class)
-class NotifySocket(
+class SocketNotifySocket(
     private val socketPath: String,
-) {
-    fun notifyContainerStart() {
+) : NotifySocket {
+    override fun notifyContainerStart() {
         Logger.debug("NotifySocket: connecting to $socketPath")
 
         memScoped {
-            // Create Unix domain socket
             val sock = socket(AF_UNIX, SOCK_STREAM, 0)
             if (sock == -1) {
                 perror("socket")
                 throw Exception("Failed to create socket")
             }
 
-            // Connect to socket path
             val addr = alloc<sockaddr_un>()
             addr.sun_family = AF_UNIX.toUShort()
 
@@ -152,7 +160,6 @@ class NotifySocket(
                 throw Exception("Socket path too long (max 108 bytes)")
             }
 
-            // Copy path into sun_path array
             for (i in pathBytes.indices) {
                 addr.sun_path[i] = pathBytes[i]
             }
@@ -167,7 +174,6 @@ class NotifySocket(
                 throw Exception("Failed to connect to socket: $socketPath")
             }
 
-            // Send start message
             val message = "start container"
             val sent = send(sock, message.cstr.ptr, message.length.toULong(), 0)
             if (sent == -1L) {

--- a/src/nativeMain/kotlin/channel/SocketChannel.kt
+++ b/src/nativeMain/kotlin/channel/SocketChannel.kt
@@ -1,0 +1,281 @@
+package channel
+
+import kotlinx.cinterop.*
+import platform.linux.*
+import platform.posix.*
+import utils.JsonCodec
+
+/**
+ * Socket-backed implementations of the channel interfaces.
+ *
+ * Each sender/receiver wraps a Unix domain socket FD. Senders serialize a
+ * [Message] to JSON and write it via send/sendmsg. Receivers do the inverse
+ * with recv/recvmsg. SCM_RIGHTS is used to pass the seccomp notify FD.
+ */
+
+@OptIn(ExperimentalForeignApi::class)
+private fun createSocketPair(): Pair<Int, Int> {
+    val sv = IntArray(2)
+    if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv.refTo(0)) != 0) {
+        perror("socketpair")
+        throw Exception("Failed to create socketpair")
+    }
+    return Pair(sv[0], sv[1])
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun sendMessage(
+    socket: Int,
+    message: Message,
+) {
+    val json = JsonCodec.encode(message)
+    val bytes = json.encodeToByteArray()
+
+    memScoped {
+        val sent = send(socket, bytes.refTo(0), bytes.size.toULong(), 0)
+        if (sent == -1L) {
+            perror("send")
+            throw Exception("Failed to send message")
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun receiveMessage(socket: Int): Message {
+    memScoped {
+        val buffer = allocArray<ByteVar>(4096)
+        val received = recv(socket, buffer, 4095.toULong(), 0)
+
+        if (received == -1L) {
+            perror("recv")
+            throw Exception("Failed to receive message")
+        }
+        if (received == 0L) {
+            throw Exception("Connection closed")
+        }
+
+        buffer[received.toInt()] = 0
+        val json = buffer.toKString()
+        return JsonCodec.decode<Message>(json)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun sendMessageWithFd(
+    socket: Int,
+    message: Message,
+    fd: Int,
+) {
+    val json = JsonCodec.encode(message)
+    val bytes = json.encodeToByteArray()
+
+    memScoped {
+        val iov = alloc<iovec>()
+        iov.iov_base = bytes.refTo(0).getPointer(this)
+        iov.iov_len = bytes.size.toULong()
+
+        val cmsgSpace = _CMSG_SPACE(sizeOf<IntVar>().toULong())
+        val cmsgBuf = allocArray<ByteVar>(cmsgSpace.toInt())
+
+        val msg = alloc<msghdr>()
+        msg.msg_name = null
+        msg.msg_namelen = 0u
+        msg.msg_iov = iov.ptr
+        msg.msg_iovlen = 1u
+        msg.msg_control = cmsgBuf
+        msg.msg_controllen = cmsgSpace
+        msg.msg_flags = 0
+
+        val cmsg = _CMSG_FIRSTHDR(msg.ptr)
+        if (cmsg != null) {
+            cmsg.pointed.cmsg_level = SOL_SOCKET
+            cmsg.pointed.cmsg_type = SCM_RIGHTS
+            cmsg.pointed.cmsg_len = _CMSG_LEN(sizeOf<IntVar>().toULong())
+
+            val dataPtr = _CMSG_DATA(cmsg)
+            if (dataPtr != null) {
+                dataPtr.reinterpret<IntVar>().pointed.value = fd
+            }
+        }
+
+        val sent = sendmsg(socket, msg.ptr, 0)
+        if (sent == -1L) {
+            perror("sendmsg")
+            throw Exception("Failed to send message with FD")
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun receiveMessageWithFd(socket: Int): Pair<Message, Int> {
+    memScoped {
+        val buffer = allocArray<ByteVar>(4096)
+        val iov = alloc<iovec>()
+        iov.iov_base = buffer
+        iov.iov_len = 4095u
+
+        val cmsgSpace = _CMSG_SPACE(sizeOf<IntVar>().toULong())
+        val cmsgBuf = allocArray<ByteVar>(cmsgSpace.toInt())
+
+        val msg = alloc<msghdr>()
+        msg.msg_name = null
+        msg.msg_namelen = 0u
+        msg.msg_iov = iov.ptr
+        msg.msg_iovlen = 1u
+        msg.msg_control = cmsgBuf
+        msg.msg_controllen = cmsgSpace
+        msg.msg_flags = 0
+
+        val received = recvmsg(socket, msg.ptr, 0)
+        if (received == -1L) {
+            perror("recvmsg")
+            throw Exception("Failed to receive message with FD")
+        }
+        if (received == 0L) {
+            throw Exception("Connection closed")
+        }
+
+        buffer[received.toInt()] = 0
+        val json = buffer.toKString()
+        val message = JsonCodec.decode<Message>(json)
+
+        var receivedFd = -1
+        val cmsg = _CMSG_FIRSTHDR(msg.ptr)
+
+        if (cmsg != null && cmsg.pointed.cmsg_level == SOL_SOCKET && cmsg.pointed.cmsg_type == SCM_RIGHTS) {
+            val dataPtr = _CMSG_DATA(cmsg)
+            if (dataPtr != null) {
+                receivedFd = dataPtr.reinterpret<IntVar>().pointed.value
+            }
+        }
+
+        if (receivedFd == -1) {
+            throw Exception("Failed to extract FD from control message")
+        }
+
+        return Pair(message, receivedFd)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+class SocketMainSender(
+    private val socket: Int,
+) : MainSender {
+    override fun fd(): Int = socket
+
+    override fun identifierMappingRequest() {
+        sendMessage(socket, Message.WriteMapping)
+    }
+
+    override fun initReady() {
+        sendMessage(socket, Message.InitReady)
+    }
+
+    override fun seccompNotifyRequest(fd: Int) {
+        sendMessageWithFd(socket, Message.SeccompNotify, fd)
+    }
+
+    override fun execFailed(error: String) {
+        sendMessage(socket, Message.ExecFailed(error))
+    }
+
+    override fun sendError(error: String) {
+        sendMessage(socket, Message.OtherError(error))
+    }
+
+    override fun close() {
+        close(socket)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+class SocketMainReceiver(
+    private val socket: Int,
+) : MainReceiver {
+    override fun fd(): Int = socket
+
+    override fun waitForMappingRequest(): Message.WriteMapping =
+        when (val msg = receiveMessage(socket)) {
+            is Message.WriteMapping -> msg
+            is Message.ExecFailed -> throw Exception("Exec failed: ${msg.error}")
+            is Message.OtherError -> throw Exception("Error: ${msg.error}")
+            else -> throw Exception("Unexpected message: $msg, expected WriteMapping")
+        }
+
+    override fun waitForInitReady() {
+        when (val msg = receiveMessage(socket)) {
+            is Message.InitReady -> return
+            is Message.ExecFailed -> throw Exception("Exec failed: ${msg.error}")
+            is Message.OtherError -> throw Exception("Error: ${msg.error}")
+            else -> throw Exception("Unexpected message: $msg, expected InitReady")
+        }
+    }
+
+    override fun waitForSeccompRequest(): Int {
+        val (msg, fd) = receiveMessageWithFd(socket)
+        return when (msg) {
+            is Message.SeccompNotify -> fd
+            is Message.ExecFailed -> throw Exception("Exec failed: ${msg.error}")
+            is Message.OtherError -> throw Exception("Error: ${msg.error}")
+            else -> throw Exception("Unexpected message: $msg, expected SeccompNotify")
+        }
+    }
+
+    override fun close() {
+        close(socket)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+class SocketInitSender(
+    private val socket: Int,
+) : InitSender {
+    override fun fd(): Int = socket
+
+    override fun mappingWritten() {
+        sendMessage(socket, Message.MappingWritten)
+    }
+
+    override fun seccompNotifyDone() {
+        sendMessage(socket, Message.SeccompNotifyDone)
+    }
+
+    override fun close() {
+        close(socket)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+class SocketInitReceiver(
+    private val socket: Int,
+) : InitReceiver {
+    override fun fd(): Int = socket
+
+    override fun waitForMappingAck() {
+        when (val msg = receiveMessage(socket)) {
+            is Message.MappingWritten -> return
+            else -> throw Exception("Unexpected message: $msg, expected MappingWritten")
+        }
+    }
+
+    override fun waitForSeccompRequestDone() {
+        when (val msg = receiveMessage(socket)) {
+            is Message.SeccompNotifyDone -> return
+            else -> throw Exception("Unexpected message: $msg, expected SeccompNotifyDone")
+        }
+    }
+
+    override fun close() {
+        close(socket)
+    }
+}
+
+fun mainChannel(): Pair<MainSender, MainReceiver> {
+    val (sender, receiver) = createSocketPair()
+    return Pair(SocketMainSender(sender), SocketMainReceiver(receiver))
+}
+
+fun initChannel(): Pair<InitSender, InitReceiver> {
+    val (sender, receiver) = createSocketPair()
+    return Pair(SocketInitSender(sender), SocketInitReceiver(receiver))
+}

--- a/src/nativeMain/kotlin/command/Create.kt
+++ b/src/nativeMain/kotlin/command/Create.kt
@@ -1,7 +1,7 @@
 package command
 
 import cgroup.Cgroup
-import channel.NotifyListener
+import channel.SocketNotifyListener
 import channel.initChannel
 import channel.mainChannel
 import kotlinx.cinterop.*
@@ -77,7 +77,7 @@ fun create(
         // Create NotifyListener before forking (will be inherited by child processes)
         val notifyListener =
             try {
-                NotifyListener(notifySocketPath)
+                SocketNotifyListener(notifySocketPath)
             } catch (e: Exception) {
                 Logger.error("failed to create notify listener: ${e.message ?: "unknown"}")
                 exit(1)

--- a/src/nativeMain/kotlin/command/Start.kt
+++ b/src/nativeMain/kotlin/command/Start.kt
@@ -1,6 +1,6 @@
 package command
 
-import channel.NotifySocket
+import channel.SocketNotifySocket
 import kotlinx.cinterop.ExperimentalForeignApi
 import logger.Logger
 import platform.posix.exit
@@ -46,7 +46,7 @@ fun start(
     val notifySocketPath = "/tmp/kontainer-$containerId.sock"
 
     // Send start signal to notify socket
-    val notifySocket = NotifySocket(notifySocketPath)
+    val notifySocket = SocketNotifySocket(notifySocketPath)
     try {
         notifySocket.notifyContainerStart()
         Logger.debug("sent start signal to container")

--- a/src/nativeTest/kotlin/channel/FakeChannel.kt
+++ b/src/nativeTest/kotlin/channel/FakeChannel.kt
@@ -1,0 +1,154 @@
+package channel
+
+/**
+ * In-memory channel implementations for tests.
+ *
+ * Each Fake* records every call. Receivers consume from preseeded queues so
+ * tests can stage the messages an init/main process would observe.
+ *
+ * Receivers throw IllegalStateException when their queue is empty — tests
+ * either preseed enough messages or assert the receive was never called.
+ */
+
+class FakeMainSender : MainSender {
+    val calls: MutableList<String> = mutableListOf()
+
+    override fun fd(): Int {
+        calls += "fd()"
+        return -1
+    }
+
+    override fun identifierMappingRequest() {
+        calls += "identifierMappingRequest()"
+    }
+
+    override fun initReady() {
+        calls += "initReady()"
+    }
+
+    override fun seccompNotifyRequest(fd: Int) {
+        calls += "seccompNotifyRequest(fd=$fd)"
+    }
+
+    override fun execFailed(error: String) {
+        calls += "execFailed(error=$error)"
+    }
+
+    override fun sendError(error: String) {
+        calls += "sendError(error=$error)"
+    }
+
+    override fun close() {
+        calls += "close()"
+    }
+}
+
+class FakeMainReceiver : MainReceiver {
+    val calls: MutableList<String> = mutableListOf()
+    val mappingRequests: ArrayDeque<Message.WriteMapping> = ArrayDeque()
+    val initReadySignals: ArrayDeque<Unit> = ArrayDeque()
+    val seccompRequestFds: ArrayDeque<Int> = ArrayDeque()
+
+    override fun fd(): Int {
+        calls += "fd()"
+        return -1
+    }
+
+    override fun waitForMappingRequest(): Message.WriteMapping {
+        calls += "waitForMappingRequest()"
+        return mappingRequests.removeFirstOrNull()
+            ?: error("no mapping request preseeded")
+    }
+
+    override fun waitForInitReady() {
+        calls += "waitForInitReady()"
+        initReadySignals.removeFirstOrNull()
+            ?: error("no init-ready signal preseeded")
+    }
+
+    override fun waitForSeccompRequest(): Int {
+        calls += "waitForSeccompRequest()"
+        return seccompRequestFds.removeFirstOrNull()
+            ?: error("no seccomp request fd preseeded")
+    }
+
+    override fun close() {
+        calls += "close()"
+    }
+}
+
+class FakeInitSender : InitSender {
+    val calls: MutableList<String> = mutableListOf()
+
+    override fun fd(): Int {
+        calls += "fd()"
+        return -1
+    }
+
+    override fun mappingWritten() {
+        calls += "mappingWritten()"
+    }
+
+    override fun seccompNotifyDone() {
+        calls += "seccompNotifyDone()"
+    }
+
+    override fun close() {
+        calls += "close()"
+    }
+}
+
+class FakeInitReceiver : InitReceiver {
+    val calls: MutableList<String> = mutableListOf()
+    val mappingAcks: ArrayDeque<Unit> = ArrayDeque()
+    val seccompDoneSignals: ArrayDeque<Unit> = ArrayDeque()
+
+    override fun fd(): Int {
+        calls += "fd()"
+        return -1
+    }
+
+    override fun waitForMappingAck() {
+        calls += "waitForMappingAck()"
+        mappingAcks.removeFirstOrNull()
+            ?: error("no mapping ack preseeded")
+    }
+
+    override fun waitForSeccompRequestDone() {
+        calls += "waitForSeccompRequestDone()"
+        seccompDoneSignals.removeFirstOrNull()
+            ?: error("no seccomp done signal preseeded")
+    }
+
+    override fun close() {
+        calls += "close()"
+    }
+}
+
+class FakeNotifyListener : NotifyListener {
+    val calls: MutableList<String> = mutableListOf()
+    val startSignals: ArrayDeque<Unit> = ArrayDeque()
+
+    override fun fd(): Int {
+        calls += "fd()"
+        return -1
+    }
+
+    override fun waitForContainerStart() {
+        calls += "waitForContainerStart()"
+        startSignals.removeFirstOrNull()
+            ?: error("no start signal preseeded")
+    }
+
+    override fun close() {
+        calls += "close()"
+    }
+}
+
+class FakeNotifySocket : NotifySocket {
+    val calls: MutableList<String> = mutableListOf()
+
+    override fun notifyContainerStart() {
+        calls += "notifyContainerStart()"
+    }
+}

--- a/src/nativeTest/kotlin/channel/FakeChannelTest.kt
+++ b/src/nativeTest/kotlin/channel/FakeChannelTest.kt
@@ -1,0 +1,94 @@
+package channel
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+class FakeChannelTest :
+    FunSpec({
+
+        // FakeMainSender records every call
+
+        test("FakeMainSender records each kind of message") {
+            val sender = FakeMainSender()
+
+            sender.identifierMappingRequest()
+            sender.initReady()
+            sender.seccompNotifyRequest(fd = 7)
+            sender.execFailed("boom")
+            sender.sendError("nope")
+            sender.close()
+
+            sender.calls shouldBe
+                listOf(
+                    "identifierMappingRequest()",
+                    "initReady()",
+                    "seccompNotifyRequest(fd=7)",
+                    "execFailed(error=boom)",
+                    "sendError(error=nope)",
+                    "close()",
+                )
+        }
+
+        // FakeMainReceiver pulls preseeded messages from queues
+
+        test("FakeMainReceiver returns preseeded mapping requests in order") {
+            val receiver = FakeMainReceiver()
+            receiver.mappingRequests.addLast(Message.WriteMapping)
+            receiver.mappingRequests.addLast(Message.WriteMapping)
+
+            receiver.waitForMappingRequest() shouldBe Message.WriteMapping
+            receiver.waitForMappingRequest() shouldBe Message.WriteMapping
+            shouldThrow<IllegalStateException> { receiver.waitForMappingRequest() }
+        }
+
+        test("FakeMainReceiver returns preseeded seccomp request FDs") {
+            val receiver = FakeMainReceiver()
+            receiver.seccompRequestFds.addLast(42)
+
+            receiver.waitForSeccompRequest() shouldBe 42
+        }
+
+        test("FakeMainReceiver throws when init-ready was not preseeded") {
+            val receiver = FakeMainReceiver()
+            shouldThrow<IllegalStateException> { receiver.waitForInitReady() }
+        }
+
+        // FakeInitSender / FakeInitReceiver
+
+        test("FakeInitSender records mapping/seccomp acks") {
+            val sender = FakeInitSender()
+            sender.mappingWritten()
+            sender.seccompNotifyDone()
+
+            sender.calls shouldContain "mappingWritten()"
+            sender.calls shouldContain "seccompNotifyDone()"
+        }
+
+        test("FakeInitReceiver returns the preseeded seccomp-done signal") {
+            val receiver = FakeInitReceiver()
+            receiver.seccompDoneSignals.addLast(Unit)
+
+            receiver.waitForSeccompRequestDone()
+
+            receiver.calls shouldBe listOf("waitForSeccompRequestDone()")
+        }
+
+        // Notify pair
+
+        test("FakeNotifySocket records notifyContainerStart") {
+            val sock = FakeNotifySocket()
+            sock.notifyContainerStart()
+            sock.calls shouldBe listOf("notifyContainerStart()")
+        }
+
+        test("FakeNotifyListener consumes preseeded start signals") {
+            val listener = FakeNotifyListener()
+            listener.startSignals.addLast(Unit)
+
+            listener.waitForContainerStart()
+
+            listener.calls shouldBe listOf("waitForContainerStart()")
+        }
+    })


### PR DESCRIPTION
## Summary

Final piece of the testability seam, after [Syscall](src/nativeMain/kotlin/syscall/Syscall.kt) ([#19](https://github.com/ternbusty/kontainer-runtime/pull/19) / [#20](https://github.com/ternbusty/kontainer-runtime/pull/20)), [FileSystem](src/nativeMain/kotlin/utils/FileSystem.kt) ([#22](https://github.com/ternbusty/kontainer-runtime/pull/22)), and [Cgroup](src/nativeMain/kotlin/cgroup/Cgroup.kt) ([#23](https://github.com/ternbusty/kontainer-runtime/pull/23)).

- [src/nativeMain/kotlin/channel/Channel.kt](src/nativeMain/kotlin/channel/Channel.kt) now declares the four message-channel interfaces: `MainSender`, `MainReceiver`, `InitSender`, `InitReceiver`. Each keeps `fd()` / `close()` so the FD-inheritance and lifecycle wiring don't need their own seam.
- [src/nativeMain/kotlin/channel/SocketChannel.kt](src/nativeMain/kotlin/channel/SocketChannel.kt) (new) is the Unix-socketpair-backed implementation. Holds `SocketMainSender` / `SocketMainReceiver` / `SocketInitSender` / `SocketInitReceiver` plus the existing private helpers (`createSocketPair`, `sendMessage`, `sendMessageWithFd`, `receiveMessage`, `receiveMessageWithFd`). The `mainChannel()` / `initChannel()` factories return the interface types.
- [src/nativeMain/kotlin/channel/NotifySocket.kt](src/nativeMain/kotlin/channel/NotifySocket.kt) makes `NotifyListener` and `NotifySocket` interfaces, with `SocketNotifyListener` (two constructors: from path, from inherited FD) and `SocketNotifySocket` as the impls.
- Construction sites — `Main.kt` (init branch reconstructing FDs across exec), `command/Create.kt` (creates the initial `NotifyListener`), `command/Start.kt` (client) — reference the `Socket*` classes directly. Everything else holds the interface type.

## Tests

- New [src/nativeTest/kotlin/channel/FakeChannel.kt](src/nativeTest/kotlin/channel/FakeChannel.kt) provides in-memory fakes for all six interfaces. Senders record every call as a string. Receivers consume from preseeded `ArrayDeque`s and throw `IllegalStateException` when nothing was preseeded — the contract that upcoming higher-layer tests rely on.
- New [src/nativeTest/kotlin/channel/FakeChannelTest.kt](src/nativeTest/kotlin/channel/FakeChannelTest.kt) sanity-checks the fakes (every sender method records, every receiver consumes from the queue and throws when empty, etc.).

## Test plan

- [ ] `build` workflow passes (compile + ktlint + kotest, including the new FakeChannelTest)
- [ ] `integration` workflow still passes — production-side this is a name change plus indirection through interfaces; the actual socket / SCM_RIGHTS protocol is unchanged