### PR TITLE
ci: pin release-please initial version to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "simple"
+      "release-type": "simple",
+      "initial-version": "0.1.0"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Why

Merging [#25](https://github.com/ternbusty/kontainer-runtime/pull/25) produced [#26](https://github.com/ternbusty/kontainer-runtime/pull/26) proposing **v1.0.0** as the first release, which is too aggressive — release-please's default behavior bumps the first release straight to `1.0.0` when no `initial-version` is set.

## What

Adds `\"initial-version\": \"0.1.0\"` to the package config in `release-please-config.json`. After this merges, release-please should regenerate [#26](https://github.com/ternbusty/kontainer-runtime/pull/26) with version `0.1.0` (and update the manifest bump from `0.0.0 -> 0.1.0` instead of `0.0.0 -> 1.0.0`).

Subsequent bumps follow normal conventional-commit semantics from `0.1.0`:
- `fix:` / `refactor:` -> `0.1.1`
- `feat:` -> `0.2.0`
- `!:` (breaking) -> `1.0.0`

If `0.1.0` is itself too forward, change the value before merging.

## Test plan

- [ ] Workflow runs on push to main and updates [#26](https://github.com/ternbusty/kontainer-runtime/pull/26) (or closes and reopens) with version `0.1.0`