### PR TITLE
ci: gate release on CI and Integration Tests passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,9 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   integration:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,15 @@ permissions:
   contents: read
 
 jobs:
+  # Gate release-please on CI + integration. Both workflows are reused via
+  # workflow_call so a broken main never produces a release / binary upload.
+  ci:
+    uses: ./.github/workflows/ci.yml
+  integration:
+    uses: ./.github/workflows/integration.yml
+
   release-please:
+    needs: [ci, integration]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Why

Right now the three workflows fire in parallel on every push to main:

- ci.yml (lint + build + kotest)
- integration.yml (ctr + verify scripts)
- release.yml (release-please + binary upload)

release-please does not wait for ci.yml or integration.yml. If a broken commit lands on main and triggers a release PR merge, the binary upload happens regardless of whether ci or integration is green. A broken commit could produce a broken release.

## What

Make ci.yml and integration.yml callable via `workflow_call` and drop their direct `push: main` triggers (PR triggers stay so PRs still get independent CI status). release.yml then invokes both as jobs, and release-please / binary-upload depend on them via `needs:`.

```yaml
jobs:
  ci:
    uses: ./.github/workflows/ci.yml
  integration:
    uses: ./.github/workflows/integration.yml
  release-please:
    needs: [ci, integration]
    ...
  build-linux-x86_64:
    needs: release-please
    if: needs.release-please.outputs.releases_created == 'true'
    ...
```

## Net behavior

- **PR opened against main**: ci.yml + integration.yml run as before, independently.
- **Push to main**: only the Release workflow runs, with ci -> integration -> release-please -> binary upload sequencing inside it. If ci or integration fails, release-please is skipped and no binary is uploaded.

The CI / Integration runs that previously appeared as separate top-level workflow runs on main now show up as nested jobs under "Release" in the Actions UI. PR runs are unchanged.

## Test plan

- [ ] PR-side CI / Integration runs continue to appear and gate the merge button (this PR itself is the test)
- [ ] After merge, the Release workflow on main runs ci -> integration -> release-please in sequence, not in parallel
- [ ] If a future broken commit lands, no release PR / binary is created