### PR TITLE
ci(docs): pin mkdocs deps via docs/requirements.txt so pip cache works

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+          cache-dependency-path: docs/requirements.txt
 
-      - run: pip install mkdocs-material
+      - run: pip install -r docs/requirements.txt
 
       - run: mkdocs build --strict
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material


### PR DESCRIPTION
## Summary

The Publish docs workflow added on #58 sets `cache: pip` on `actions/setup-python@v5` but there was no `requirements.txt` or `pyproject.toml` in the repo. The action failed on the first push to main after merge.

> No file in /home/runner/work/kontainer-runtime/kontainer-runtime matched to [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository

See run [28491422298](https://github.com/ternbusty/kontainer-runtime/actions/runs/28491422298).

## Fix

* Add [`docs/requirements.txt`](https://github.com/ternbusty/kontainer-runtime/blob/ci/docs-workflow-pip-cache/docs/requirements.txt) with `mkdocs-material`
* Point `cache-dependency-path` at that file so the cache key is stable
* Install via `pip install -r docs/requirements.txt` in the workflow

## Test plan

- [ ] Publish docs workflow succeeds on this PR's push (workflow only triggers on main, so validate by merging or by using `workflow_dispatch` after merge)